### PR TITLE
Enbiggen the windows latency

### DIFF
--- a/leveldb/cache/cache_test.go
+++ b/leveldb/cache/cache_test.go
@@ -294,7 +294,7 @@ func TestLRUCache_GetLatency(t *testing.T) {
 
 	delay := 3 * time.Millisecond
 	if runtime.GOOS == "windows" && os.Getenv("CI") == "true" {
-		delay = 12 * time.Second
+		delay = 52 * time.Second
 	}
 
 	const (


### PR DESCRIPTION
In a handful of my tests, this is still about 25% of what reality is. So, embiggen it :|

https://github.com/kolide/goleveldb/actions/runs/14036003074/job/39294054236