### PR TITLE
leveldb: handle errors in makeInternalKey calls

### DIFF
--- a/leveldb/batch.go
+++ b/leveldb/batch.go
@@ -219,8 +219,12 @@ func (b *Batch) decode(data []byte, expectedLen int) error {
 
 func (b *Batch) putMem(seq uint64, mdb *memdb.DB) error {
 	var ik []byte
+	var err error
 	for i, index := range b.index {
-		ik = makeInternalKey(ik, index.k(b.data), seq+uint64(i), index.keyType)
+		ik, err = makeInternalKey(ik, index.k(b.data), seq+uint64(i), index.keyType)
+		if err != nil {
+			return err
+		}
 		if err := mdb.Put(ik, index.v(b.data)); err != nil {
 			return err
 		}
@@ -330,7 +334,11 @@ func decodeBatchToMem(data []byte, expectSeq uint64, mdb *memdb.DB) (seq uint64,
 		if i >= batchLen {
 			return newErrBatchCorrupted("invalid records length")
 		}
-		ik = makeInternalKey(ik, index.k(data), seq+uint64(i), index.keyType)
+		var ikErr error
+		ik, ikErr = makeInternalKey(ik, index.k(data), seq+uint64(i), index.keyType)
+		if ikErr != nil {
+			return ikErr
+		}
 		if err := mdb.Put(ik, index.v(data)); err != nil {
 			return err
 		}

--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -779,7 +779,10 @@ func memGet(mdb *memdb.DB, ikey internalKey, icmp *iComparer) (ok bool, mv []byt
 }
 
 func (db *DB) get(auxm *memdb.DB, auxt tFiles, key []byte, seq uint64, ro *opt.ReadOptions) (value []byte, err error) {
-	ikey := makeInternalKey(nil, key, seq, keyTypeSeek)
+	ikey, err := makeInternalKey(nil, key, seq, keyTypeSeek)
+	if err != nil {
+		return nil, err
+	}
 
 	if auxm != nil {
 		if ok, mv, me := memGet(auxm, ikey, db.s.icmp); ok {
@@ -817,7 +820,10 @@ func nilIfNotFound(err error) error {
 }
 
 func (db *DB) has(auxm *memdb.DB, auxt tFiles, key []byte, seq uint64, ro *opt.ReadOptions) (ret bool, err error) {
-	ikey := makeInternalKey(nil, key, seq, keyTypeSeek)
+	ikey, err := makeInternalKey(nil, key, seq, keyTypeSeek)
+	if err != nil {
+		return false, err
+	}
 
 	if auxm != nil {
 		if ok, _, me := memGet(auxm, ikey, db.s.icmp); ok {
@@ -1142,8 +1148,14 @@ func (db *DB) SizeOf(ranges []util.Range) (Sizes, error) {
 
 	sizes := make(Sizes, 0, len(ranges))
 	for _, r := range ranges {
-		imin := makeInternalKey(nil, r.Start, keyMaxSeq, keyTypeSeek)
-		imax := makeInternalKey(nil, r.Limit, keyMaxSeq, keyTypeSeek)
+		imin, err := makeInternalKey(nil, r.Start, keyMaxSeq, keyTypeSeek)
+		if err != nil {
+			return nil, err
+		}
+		imax, err := makeInternalKey(nil, r.Limit, keyMaxSeq, keyTypeSeek)
+		if err != nil {
+			return nil, err
+		}
 		start, err := v.offsetOf(imin)
 		if err != nil {
 			return nil, err

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -629,7 +629,12 @@ func (db *DB) tableRangeCompaction(level int, umin, umax []byte) error {
 			m := 1
 			for i := m; i < len(v.levels); i++ {
 				tables := v.levels[i]
-				if tables.overlaps(db.s.icmp, umin, umax, false) {
+				overlaps, err := tables.overlaps(db.s.icmp, umin, umax, false)
+				if err != nil {
+					v.release()
+					return err
+				}
+				if overlaps {
 					m = i
 				}
 			}

--- a/leveldb/db_iter.go
+++ b/leveldb/db_iter.go
@@ -65,10 +65,22 @@ func (db *DB) newIterator(auxm *memDB, auxt tFiles, seq uint64, slice *util.Rang
 	if slice != nil {
 		islice = &util.Range{}
 		if slice.Start != nil {
-			islice.Start = makeInternalKey(nil, slice.Start, keyMaxSeq, keyTypeSeek)
+			var err error
+			islice.Start, err = makeInternalKey(nil, slice.Start, keyMaxSeq, keyTypeSeek)
+			if err != nil {
+				// Return an iterator with the error set
+				iter := &dbIter{err: err}
+				return iter
+			}
 		}
 		if slice.Limit != nil {
-			islice.Limit = makeInternalKey(nil, slice.Limit, keyMaxSeq, keyTypeSeek)
+			var err error
+			islice.Limit, err = makeInternalKey(nil, slice.Limit, keyMaxSeq, keyTypeSeek)
+			if err != nil {
+				// Return an iterator with the error set
+				iter := &dbIter{err: err}
+				return iter
+			}
 		}
 	}
 	rawIter := db.newRawIterator(auxm, auxt, islice, ro)
@@ -191,7 +203,11 @@ func (i *dbIter) Seek(key []byte) bool {
 		return false
 	}
 
-	ikey := makeInternalKey(nil, key, i.seq, keyTypeSeek)
+	ikey, err := makeInternalKey(nil, key, i.seq, keyTypeSeek)
+	if err != nil {
+		i.err = err
+		return false
+	}
 	if i.iter.Seek(ikey) {
 		i.dir = dirSOI
 		return i.next()

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -277,7 +277,11 @@ func (h *dbHarness) allEntriesFor(key, want string) {
 	db := h.db
 	s := db.s
 
-	ikey := makeInternalKey(nil, []byte(key), keyMaxSeq, keyTypeVal)
+	ikey, err := makeInternalKey(nil, []byte(key), keyMaxSeq, keyTypeVal)
+	if err != nil {
+		t.Fatal("makeInternalKey error:", err)
+		return
+	}
 	iter := db.newRawIterator(nil, nil, nil, nil)
 	if !iter.Seek(ikey) && iter.Error() != nil {
 		t.Error("AllEntries: error during seek, err: ", iter.Error())
@@ -2619,7 +2623,11 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 			key := []byte(fmt.Sprintf("%09d", k))
 			seq += nSeq - 1
 			for x := uint64(0); x < nSeq; x++ {
-				if err := tw.append(makeInternalKey(nil, key, seq-x, keyTypeVal), value); err != nil {
+				ik, ikErr := makeInternalKey(nil, key, seq-x, keyTypeVal)
+				if ikErr != nil {
+					t.Fatal("makeInternalKey error:", ikErr)
+				}
+				if err := tw.append(ik, value); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/leveldb/db_transaction.go
+++ b/leveldb/db_transaction.go
@@ -116,7 +116,11 @@ func (tr *Transaction) flush() error {
 }
 
 func (tr *Transaction) put(kt keyType, key, value []byte) error {
-	tr.ikScratch = makeInternalKey(tr.ikScratch, key, tr.seq+1, kt)
+	var err error
+	tr.ikScratch, err = makeInternalKey(tr.ikScratch, key, tr.seq+1, kt)
+	if err != nil {
+		return err
+	}
 	if tr.mem.Free() < len(tr.ikScratch)+len(value) {
 		if err := tr.flush(); err != nil {
 			return err

--- a/leveldb/key.go
+++ b/leveldb/key.go
@@ -72,17 +72,17 @@ func init() {
 
 type internalKey []byte
 
-func makeInternalKey(dst, ukey []byte, seq uint64, kt keyType) internalKey {
+func makeInternalKey(dst, ukey []byte, seq uint64, kt keyType) (internalKey, error) {
 	if seq > keyMaxSeq {
-		panic("leveldb: invalid sequence number")
+		return nil, fmt.Errorf("leveldb: invalid sequence number")
 	} else if kt > keyTypeVal {
-		panic("leveldb: invalid type")
+		return nil, fmt.Errorf("leveldb: invalid type")
 	}
 
 	dst = ensureBuffer(dst, len(ukey)+8)
 	copy(dst, ukey)
 	binary.LittleEndian.PutUint64(dst[len(ukey):], (seq<<8)|uint64(kt))
-	return internalKey(dst)
+	return internalKey(dst), nil
 }
 
 func parseInternalKey(ik []byte) (ukey []byte, seq uint64, kt keyType, err error) {

--- a/leveldb/key.go
+++ b/leveldb/key.go
@@ -74,9 +74,9 @@ type internalKey []byte
 
 func makeInternalKey(dst, ukey []byte, seq uint64, kt keyType) (internalKey, error) {
 	if seq > keyMaxSeq {
-		return nil, fmt.Errorf("leveldb: invalid sequence number")
+		return nil, errors.New("leveldb: invalid sequence number")
 	} else if kt > keyTypeVal {
-		return nil, fmt.Errorf("leveldb: invalid type")
+		return nil, errors.New("leveldb: invalid type")
 	}
 
 	dst = ensureBuffer(dst, len(ukey)+8)

--- a/leveldb/key.go
+++ b/leveldb/key.go
@@ -74,9 +74,9 @@ type internalKey []byte
 
 func makeInternalKey(dst, ukey []byte, seq uint64, kt keyType) (internalKey, error) {
 	if seq > keyMaxSeq {
-		return nil, errors.New("leveldb: invalid sequence number")
+		return nil, fmt.Errorf("leveldb: invalid sequence number (max %d but got %d)", keyMaxSeq, seq)
 	} else if kt > keyTypeVal {
-		return nil, errors.New("leveldb: invalid type")
+		return nil, fmt.Errorf("leveldb: invalid type (max %d but got %d)", keyTypeVal, kt)
 	}
 
 	dst = ensureBuffer(dst, len(ukey)+8)

--- a/leveldb/key_test.go
+++ b/leveldb/key_test.go
@@ -11,15 +11,14 @@ import (
 	"testing"
 
 	"github.com/kolide/goleveldb/leveldb/comparer"
+	"github.com/stretchr/testify/require"
 )
 
 var defaultIComparer = &iComparer{comparer.DefaultComparer}
 
-func ikey(key string, seq uint64, kt keyType) internalKey {
+func ikey(t *testing.T, key string, seq uint64, kt keyType) internalKey {
 	ik, err := makeInternalKey(nil, []byte(key), seq, kt)
-	if err != nil {
-		panic(err) // Test helper - should not fail with valid parameters
-	}
+	require.NoError(t, err, "making internal key")
 	return ik
 }
 
@@ -42,7 +41,7 @@ func shortSuccessor(b []byte) []byte {
 }
 
 func testSingleKey(t *testing.T, key string, seq uint64, kt keyType) {
-	ik := ikey(key, seq, kt)
+	ik := ikey(t, key, seq, kt)
 
 	if !bytes.Equal(ik.ukey(), []byte(key)) {
 		t.Errorf("user key does not equal, got %v, want %v", string(ik.ukey()), key)
@@ -95,43 +94,43 @@ func assertBytes(t *testing.T, want, got []byte) {
 
 func TestInternalKeyShortSeparator(t *testing.T) {
 	// When user keys are same
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("foo", 99, keyTypeVal)))
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("foo", 101, keyTypeVal)))
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("foo", 100, keyTypeVal)))
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("foo", 100, keyTypeDel)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "foo", 99, keyTypeVal)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "foo", 101, keyTypeVal)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "foo", 100, keyTypeVal)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "foo", 100, keyTypeDel)))
 
 	// When user keys are misordered
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("bar", 99, keyTypeVal)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "bar", 99, keyTypeVal)))
 
 	// When user keys are different, but correctly ordered
-	assertBytes(t, ikey("g", keyMaxSeq, keyTypeSeek),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("hello", 200, keyTypeVal)))
+	assertBytes(t, ikey(t, "g", keyMaxSeq, keyTypeSeek),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "hello", 200, keyTypeVal)))
 
 	// When start user key is prefix of limit user key
-	assertBytes(t, ikey("foo", 100, keyTypeVal),
-		shortSep(ikey("foo", 100, keyTypeVal),
-			ikey("foobar", 200, keyTypeVal)))
+	assertBytes(t, ikey(t, "foo", 100, keyTypeVal),
+		shortSep(ikey(t, "foo", 100, keyTypeVal),
+			ikey(t, "foobar", 200, keyTypeVal)))
 
 	// When limit user key is prefix of start user key
-	assertBytes(t, ikey("foobar", 100, keyTypeVal),
-		shortSep(ikey("foobar", 100, keyTypeVal),
-			ikey("foo", 200, keyTypeVal)))
+	assertBytes(t, ikey(t, "foobar", 100, keyTypeVal),
+		shortSep(ikey(t, "foobar", 100, keyTypeVal),
+			ikey(t, "foo", 200, keyTypeVal)))
 }
 
 func TestInternalKeyShortestSuccessor(t *testing.T) {
-	assertBytes(t, ikey("g", keyMaxSeq, keyTypeSeek),
-		shortSuccessor(ikey("foo", 100, keyTypeVal)))
-	assertBytes(t, ikey("\xff\xff", 100, keyTypeVal),
-		shortSuccessor(ikey("\xff\xff", 100, keyTypeVal)))
+	assertBytes(t, ikey(t, "g", keyMaxSeq, keyTypeSeek),
+		shortSuccessor(ikey(t, "foo", 100, keyTypeVal)))
+	assertBytes(t, ikey(t, "\xff\xff", 100, keyTypeVal),
+		shortSuccessor(ikey(t, "\xff\xff", 100, keyTypeVal)))
 }

--- a/leveldb/key_test.go
+++ b/leveldb/key_test.go
@@ -16,7 +16,11 @@ import (
 var defaultIComparer = &iComparer{comparer.DefaultComparer}
 
 func ikey(key string, seq uint64, kt keyType) internalKey {
-	return makeInternalKey(nil, []byte(key), seq, kt)
+	ik, err := makeInternalKey(nil, []byte(key), seq, kt)
+	if err != nil {
+		panic(err) // Test helper - should not fail with valid parameters
+	}
+	return ik
 }
 
 func shortSep(a, b []byte) []byte {

--- a/leveldb/session_record_test.go
+++ b/leveldb/session_record_test.go
@@ -9,6 +9,8 @@ package leveldb
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func decodeEncode(v *sessionRecord) (res bool, err error) {
@@ -47,19 +49,13 @@ func TestSessionRecord_EncodeDecode(t *testing.T) {
 	for ; i < 4; i++ {
 		test()
 		ik1, err1 := makeInternalKey(nil, []byte("foo"), uint64(big+500+1), keyTypeVal)
-		if err1 != nil {
-			panic(err1) // Test code - should not fail with valid parameters
-		}
+		require.NoError(t, err1, "making internal key for foo")
 		ik2, err2 := makeInternalKey(nil, []byte("zoo"), uint64(big+600+1), keyTypeDel)
-		if err2 != nil {
-			panic(err2) // Test code - should not fail with valid parameters
-		}
+		require.NoError(t, err2, "making internal key for zoo")
 		v.addTable(3, big+300+i, big+400+i, ik1, ik2)
 		v.delTable(4, big+700+i)
 		ik3, err3 := makeInternalKey(nil, []byte("x"), uint64(big+900+1), keyTypeVal)
-		if err3 != nil {
-			panic(err3) // Test code - should not fail with valid parameters
-		}
+		require.NoError(t, err3, "making internal key for x")
 		v.addCompPtr(int(i), ik3)
 	}
 

--- a/leveldb/session_record_test.go
+++ b/leveldb/session_record_test.go
@@ -46,11 +46,21 @@ func TestSessionRecord_EncodeDecode(t *testing.T) {
 
 	for ; i < 4; i++ {
 		test()
-		v.addTable(3, big+300+i, big+400+i,
-			makeInternalKey(nil, []byte("foo"), uint64(big+500+1), keyTypeVal),
-			makeInternalKey(nil, []byte("zoo"), uint64(big+600+1), keyTypeDel))
+		ik1, err1 := makeInternalKey(nil, []byte("foo"), uint64(big+500+1), keyTypeVal)
+		if err1 != nil {
+			panic(err1) // Test code - should not fail with valid parameters
+		}
+		ik2, err2 := makeInternalKey(nil, []byte("zoo"), uint64(big+600+1), keyTypeDel)
+		if err2 != nil {
+			panic(err2) // Test code - should not fail with valid parameters
+		}
+		v.addTable(3, big+300+i, big+400+i, ik1, ik2)
 		v.delTable(4, big+700+i)
-		v.addCompPtr(int(i), makeInternalKey(nil, []byte("x"), uint64(big+900+1), keyTypeVal))
+		ik3, err3 := makeInternalKey(nil, []byte("x"), uint64(big+900+1), keyTypeVal)
+		if err3 != nil {
+			panic(err3) // Test code - should not fail with valid parameters
+		}
+		v.addCompPtr(int(i), ik3)
 	}
 
 	v.setComparer("foo")

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -165,27 +165,31 @@ func (tf tFiles) searchMaxUkey(icmp *iComparer, umax []byte) int {
 
 // Returns true if given key range overlaps with one or more
 // tables key range. If unsorted is true then binary search will not be used.
-func (tf tFiles) overlaps(icmp *iComparer, umin, umax []byte, unsorted bool) bool {
+func (tf tFiles) overlaps(icmp *iComparer, umin, umax []byte, unsorted bool) (bool, error) {
 	if unsorted {
 		// Check against all files.
 		for _, t := range tf {
 			if t.overlaps(icmp, umin, umax) {
-				return true
+				return true, nil
 			}
 		}
-		return false
+		return false, nil
 	}
 
 	i := 0
 	if len(umin) > 0 {
 		// Find the earliest possible internal key for min.
-		i = tf.searchMax(icmp, makeInternalKey(nil, umin, keyMaxSeq, keyTypeSeek))
+		ikey, err := makeInternalKey(nil, umin, keyMaxSeq, keyTypeSeek)
+		if err != nil {
+			return false, err
+		}
+		i = tf.searchMax(icmp, ikey)
 	}
 	if i >= len(tf) {
 		// Beginning of range is after all files, so no overlap.
-		return false
+		return false, nil
 	}
-	return !tf[i].before(icmp, umax)
+	return !tf[i].before(icmp, umax), nil
 }
 
 // Returns tables whose its key range overlaps with given key range.

--- a/leveldb/table_test.go
+++ b/leveldb/table_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kolide/goleveldb/leveldb/storage"
 	"github.com/kolide/goleveldb/leveldb/testutil"
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOverlaps(t *testing.T) {
@@ -41,9 +42,7 @@ func TestGetOverlaps(t *testing.T) {
 			return key
 		}
 		ik, err := makeInternalKey(nil, tmp, 0, typ)
-		if err != nil {
-			panic(err) // Test helper - should not fail with valid parameters
-		}
+		require.NoError(t, err, "making internal key")
 		return []byte(ik)
 	}
 
@@ -139,9 +138,7 @@ func benchmarkGetOverlap(b *testing.B, level int, size int) {
 			return key
 		}
 		ik, err := makeInternalKey(nil, tmp, 0, typ)
-		if err != nil {
-			panic(err) // Test helper - should not fail with valid parameters
-		}
+		require.NoError(b, err, "making internal key")
 		return []byte(ik)
 	}
 

--- a/leveldb/table_test.go
+++ b/leveldb/table_test.go
@@ -40,7 +40,11 @@ func TestGetOverlaps(t *testing.T) {
 			copy(key, tmp)
 			return key
 		}
-		return []byte(makeInternalKey(nil, tmp, 0, typ))
+		ik, err := makeInternalKey(nil, tmp, 0, typ)
+		if err != nil {
+			panic(err) // Test helper - should not fail with valid parameters
+		}
+		return []byte(ik)
 	}
 
 	rec := &sessionRecord{}
@@ -134,7 +138,11 @@ func benchmarkGetOverlap(b *testing.B, level int, size int) {
 			copy(key, tmp)
 			return key
 		}
-		return []byte(makeInternalKey(nil, tmp, 0, typ))
+		ik, err := makeInternalKey(nil, tmp, 0, typ)
+		if err != nil {
+			panic(err) // Test helper - should not fail with valid parameters
+		}
+		return []byte(ik)
 	}
 
 	rec := &sessionRecord{}

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -332,12 +332,25 @@ func (v *version) pickMemdbLevel(umin, umax []byte, maxLevel int) (level int) {
 		if len(v.levels) == 0 {
 			return maxLevel
 		}
-		if !v.levels[0].overlaps(v.s.icmp, umin, umax, true) {
+		// l0Overlaps is true if the level 0 files overlap with the given range
+		l0Overlaps, err := v.levels[0].overlaps(v.s.icmp, umin, umax, true)
+		if err != nil {
+			// Conservative: if we can't determine overlaps, use maxLevel
+			return maxLevel
+		}
+		if !l0Overlaps {
 			var overlaps tFiles
 			for ; level < maxLevel; level++ {
-				if pLevel := level + 1; pLevel >= len(v.levels) {
+				pLevel := level + 1
+				if pLevel >= len(v.levels) {
 					return maxLevel
-				} else if v.levels[pLevel].overlaps(v.s.icmp, umin, umax, false) {
+				}
+				pLevelOverlaps, err := v.levels[pLevel].overlaps(v.s.icmp, umin, umax, false)
+				if err != nil {
+					// Conservative: if we can't determine overlaps, break early
+					break
+				}
+				if pLevelOverlaps {
 					break
 				}
 				if gpLevel := level + 2; gpLevel < len(v.levels) {

--- a/leveldb/version_test.go
+++ b/leveldb/version_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kolide/goleveldb/leveldb/storage"
 	"github.com/kolide/goleveldb/leveldb/testutil"
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 type testFileRec struct {
@@ -38,9 +39,7 @@ func TestVersionStaging(t *testing.T) {
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
 		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
-		if err != nil {
-			panic(err) // Test helper - should not fail with valid parameters
-		}
+		require.NoError(t, err, "making internal key")
 		return []byte(ik)
 	}
 
@@ -249,9 +248,7 @@ func TestVersionReference(t *testing.T) {
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
 		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
-		if err != nil {
-			panic(err) // Test helper - should not fail with valid parameters
-		}
+		require.NoError(t, err, "making internal key")
 		return []byte(ik)
 	}
 
@@ -406,9 +403,7 @@ func benchmarkVersionStaging(b *testing.B, trivial bool, size int) {
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
 		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
-		if err != nil {
-			panic(err) // Test helper - should not fail with valid parameters
-		}
+		require.NoError(b, err, "making internal key")
 		return []byte(ik)
 	}
 

--- a/leveldb/version_test.go
+++ b/leveldb/version_test.go
@@ -37,7 +37,11 @@ func TestVersionStaging(t *testing.T) {
 	tmp := make([]byte, 4)
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
-		return []byte(makeInternalKey(nil, tmp, 0, keyTypeVal))
+		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
+		if err != nil {
+			panic(err) // Test helper - should not fail with valid parameters
+		}
+		return []byte(ik)
 	}
 
 	for i, x := range []struct {
@@ -244,7 +248,11 @@ func TestVersionReference(t *testing.T) {
 	tmp := make([]byte, 4)
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
-		return []byte(makeInternalKey(nil, tmp, 0, keyTypeVal))
+		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
+		if err != nil {
+			panic(err) // Test helper - should not fail with valid parameters
+		}
+		return []byte(ik)
 	}
 
 	// Test normal version task correctness
@@ -397,7 +405,11 @@ func benchmarkVersionStaging(b *testing.B, trivial bool, size int) {
 	tmp := make([]byte, 4)
 	mik := func(i uint64) []byte {
 		binary.BigEndian.PutUint32(tmp, uint32(i))
-		return []byte(makeInternalKey(nil, tmp, 0, keyTypeVal))
+		ik, err := makeInternalKey(nil, tmp, 0, keyTypeVal)
+		if err != nil {
+			panic(err) // Test helper - should not fail with valid parameters
+		}
+		return []byte(ik)
 	}
 
 	rec := &sessionRecord{}


### PR DESCRIPTION
This pull request introduces error handling for the `makeInternalKey` function across the codebase, replacing panic calls with proper error propagation. This improves the robustness and maintainability of the code by ensuring that invalid inputs are handled gracefully. The changes affect both production code and test cases.

### Key Changes

#### Error Handling for `makeInternalKey` in Production Code
1. **Updated `makeInternalKey` to return errors**: The function now returns an error instead of panicking when invalid sequence numbers or key types are provided. (`leveldb/key.go`, [leveldb/key.goL75-R85](diffhunk://#diff-eec946d8980de28a49deef2e0457df4ddfaaf3b3961b5b848519743f6e33a5c9L75-R85))
2. **Propagated errors in database operations**:
   - Added error handling for `makeInternalKey` in critical database functions like `putMem`, `decodeBatchToMem`, `get`, `has`, and `SizeOf`. (`leveldb/batch.go`, [[1]](diffhunk://#diff-487609193acc32e119dee7b4453bb7065275feaf1047295e0ead5631dc6cfc6eR222-R227) [[2]](diffhunk://#diff-487609193acc32e119dee7b4453bb7065275feaf1047295e0ead5631dc6cfc6eL333-R341); `leveldb/db.go`, [[3]](diffhunk://#diff-1030124f41de5a75168f2b8889e82e5bbbfc19e0095e3ffad5f6b8c12fd1173bL782-R785) [[4]](diffhunk://#diff-1030124f41de5a75168f2b8889e82e5bbbfc19e0095e3ffad5f6b8c12fd1173bL820-R826) [[5]](diffhunk://#diff-1030124f41de5a75168f2b8889e82e5bbbfc19e0095e3ffad5f6b8c12fd1173bL1145-R1158)
   - Ensured that errors are returned appropriately in iterator creation and seeking operations. (`leveldb/db_iter.go`, [[1]](diffhunk://#diff-150ac9951bdc553737aef5ae35d934ce3a87544b866291b9c319dd2c124f07c8L68-R83) [[2]](diffhunk://#diff-150ac9951bdc553737aef5ae35d934ce3a87544b866291b9c319dd2c124f07c8L194-R210)
   - Introduced error handling in transaction-related operations. (`leveldb/db_transaction.go`, [leveldb/db_transaction.goL119-R123](diffhunk://#diff-2d6170c51034e1ffb3977a5b8166e6c240796e8eb7735b18b3f25e699bc150d5L119-R123))

3. **Improved error handling in compaction and table operations**:
   - Updated the `overlaps` method to return errors instead of assuming valid inputs. (`leveldb/table.go`, [leveldb/table.goL168-R192](diffhunk://#diff-2eeecdd8095ec6ae597bb0838e50671953126a4fe9374bd5e49a14911b1d8b43L168-R192))
   - Adjusted compaction-related methods to handle errors from `overlaps`. (`leveldb/db_compaction.go`, [[1]](diffhunk://#diff-59deb01b37b7b818e76363c528f82bf039a17652232d7ff0f4a34b0b823264e9L632-R637); `leveldb/version.go`, [[2]](diffhunk://#diff-fdcffda55c3c36166eeebdd6d94b3b780b10bd77fca7729e321b53174e27210fL335-R353)

#### Error Handling in Test Code
4. **Updated test helpers to handle errors**:
   - Modified test functions to handle errors from `makeInternalKey` by using `panic` for invalid parameters, as these are expected to be valid in test scenarios. (`leveldb/key_test.go`, [[1]](diffhunk://#diff-0a1015e94ad4eafa1b62dd0db23fea674ffe119da806f933bd69f3345c0a29f8L19-R23); `leveldb/session_record_test.go`, [[2]](diffhunk://#diff-e57e6b375d70783242b0641e346d790e739ac9323d2d4f52b7a11da26a0d4429L49-R63); `leveldb/table_test.go`, [[3]](diffhunk://#diff-496fb7977dd0f1e221d5ce96a711ff2ca52f65527e34fd540a97284711c73b12L43-R47) [[4]](diffhunk://#diff-496fb7977dd0f1e221d5ce96a711ff2ca52f65527e34fd540a97284711c73b12L137-R145); `leveldb/version_test.go`, [[5]](diffhunk://#diff-dde3a1141c22fcc4c6c653b50249c8bdfdc18d8ae8688d1a29344ab57e1dcc50L40-R44) [[6]](diffhunk://#diff-dde3a1141c22fcc4c6c653b50249c8bdfdc18d8ae8688d1a29344ab57e1dcc50L247-R255) [[7]](diffhunk://#diff-dde3a1141c22fcc4c6c653b50249c8bdfdc18d8ae8688d1a29344ab57e1dcc50L400-R412)

### Benefits
- **Improved robustness**: The changes ensure that invalid inputs are handled gracefully, reducing the risk of crashes in production.
- **Better maintainability**: By propagating errors, the codebase becomes easier to debug and extend.